### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -36,7 +36,7 @@ func (s *Server) Start() error {
 	}
 
 	mux := http.NewServeMux()
-	
+
 	// Register routes
 	mux.HandleFunc("/", s.handleLogin)
 	mux.HandleFunc("/login", s.handleLoginSubmit)
@@ -110,11 +110,11 @@ func (s *Server) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	username := r.FormValue("username")
-	password := r.FormValue("password")
+	// password := r.FormValue("password")
 
 	// TODO: Implement actual authentication
 	log.Printf("Login attempt: username=%s\n", username)
-	
+
 	// For now, just redirect back to the login page
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
@@ -127,7 +127,7 @@ func (s *Server) openBrowser() {
 		log.Printf("Error parsing URL: %v\n", err)
 		return
 	}
-	
+
 	// Use Fyne's OpenURL function to open the browser
 	err = s.app.OpenURL(parsedURL)
 	if err != nil {

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -113,8 +113,8 @@ func (s *Server) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 	password := r.FormValue("password")
 
 	// TODO: Implement actual authentication
-	log.Printf("Login attempt: username=%s, password=%s\n", username, password)
-
+	log.Printf("Login attempt: username=%s\n", username)
+	
 	// For now, just redirect back to the login page
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/sparkoo/racemate-desktop/security/code-scanning/2](https://github.com/sparkoo/racemate-desktop/security/code-scanning/2)

To fix the issue, we need to ensure that the sensitive information (password) is not logged in plain text. Instead, we can log only the username and omit the password entirely. This approach aligns with the principle of minimizing the exposure of sensitive data. The logging statement on line 116 should be updated to exclude the password. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
